### PR TITLE
GPC-646: Ignore potential vulnerability

### DIFF
--- a/lambdas/.trivyignore
+++ b/lambdas/.trivyignore
@@ -1,2 +1,5 @@
 # GPC-632
 CVE-2023-4586
+
+# GPC-646
+GHSA-xpw8-rcwv-8f8p

--- a/lib/.trivyignore
+++ b/lib/.trivyignore
@@ -1,2 +1,5 @@
 # GPC-632
 CVE-2023-4586
+
+# GPC-646
+GHSA-xpw8-rcwv-8f8p


### PR DESCRIPTION
Not looked at this in much detail yet, but there doesn't appear to be a fix available yet through the AWS dependencies that pull this in