### PR TITLE
GPC-642: Add new least-privilege security group (VpcSecurityGroup)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -224,6 +224,16 @@ Resources:
               StringEquals:
                 'aws:SourceAccount': !Sub "${AWS::AccountId}"
 
+  VpcSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Limits security group egress traffic
+      SecurityGroupEgress:
+        - CidrIp: 127.0.0.1/32
+          IpProtocol: "-1"
+      VpcId:
+        Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -228,11 +228,12 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Limits security group egress traffic
-      SecurityGroupEgress:
-        - CidrIp: 127.0.0.1/32
-          IpProtocol: "-1"
       VpcId:
         Fn::ImportValue: !Sub ${VpcStackName}-VpcId
+      SecurityGroupEgress:
+        - Description: Limit security group egress traffic
+          CidrIp: 127.0.0.1/32
+          IpProtocol: "-1"
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Cannot delete default security groups but can delete the rules that allow all traffic - this needs to be done through the console (cannot be done through cloudformation).

Have added new least-privilege security group into the template and have deleted the default security ingress/egress rules (https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2)